### PR TITLE
Xcode 7.0b

### DIFF
--- a/MCLog/MCLog-Info.plist
+++ b/MCLog/MCLog-Info.plist
@@ -33,6 +33,7 @@
 		<string>37B30044-3B14-46BA-ABAA-F01000C27B63</string>
 		<string>AD68E85B-441B-4301-B564-A45E4919A6AD</string>
 		<string>7FDF5C7A-131F-4ABB-9EDC-8C5F8F0B8A90</string>
+		<string>AABB7188-E14E-4433-AD3B-5CD791EAD9A3</string>
 	</array>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2014年 Yuhua Chen. All rights reserved.</string>

--- a/MCLog/MCLog.m
+++ b/MCLog/MCLog.m
@@ -406,7 +406,7 @@ static void *kLastAttributeKey;
 
 - (void)fixAttributesInRange:(NSRange)range
 {
-    OriginalFixAttributesInRangeIMP(self, _cmd, range);
+//    OriginalFixAttributesInRangeIMP(self, _cmd, range);
     
     __block NSRange lastRange = NSMakeRange(range.location, 0);
     NSMutableDictionary *attrs = [NSMutableDictionary dictionary];


### PR DESCRIPTION
I added support for Xcode 7.0b3
and find at
MCLog.m : 409     OriginalFixAttributesInRangeIMP(self, _cmd, range);
will be crash in Xcode7

but i have't Xcode6 to test it
(in osx 10.11 can't use Xcode6)

thanks